### PR TITLE
Expose URL for h264 stream

### DIFF
--- a/pydroid_ipcam.py
+++ b/pydroid_ipcam.py
@@ -50,6 +50,11 @@ class PyDroidIPCam:
         return f"{self.base_url}/video"
 
     @property
+    def h264_url(self) -> str:
+        """Return h264 url."""
+        return f"rtsp://{self._host}:{self._port}/h264_pcm.sdp"
+
+    @property
     def image_url(self) -> str:
         """Return snapshot image url."""
         return f"{self.base_url}/shot.jpg"


### PR DESCRIPTION
Android IP Webcam currently supports h264 streaming. This little patch exposes that stream URL.

The final goal is to enable home-assistant to record streams from the android_ip_webcam component. Current implementation of android_ip_webcam uses the MJPEG camera that has no support for stream.

This is the first step to that goal, next steps should be focused on modify the android_ip_webcam component.