### PR TITLE
Fix sensor value delay

### DIFF
--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -164,7 +164,7 @@ class PyDroidIPCam:
             container = self.sensor_data.get(sensor)
             unit = container.get("unit")
             data_point = container.get("data", [[0, [0.0]]])
-            if data_point and data_point[0]:
+            if data_point and data_point[-1]:
                 value = data_point[-1][-1][0]
         except (ValueError, KeyError, AttributeError):
             pass

--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -165,7 +165,7 @@ class PyDroidIPCam:
             unit = container.get("unit")
             data_point = container.get("data", [[0, [0.0]]])
             if data_point and data_point[0]:
-                value = data_point[0][-1][0]
+                value = data_point[-1][-1][0]
         except (ValueError, KeyError, AttributeError):
             pass
 


### PR DESCRIPTION
In response of /sensors.json, some sensors contain multiple values of time series as in the sample below.
Current program picks up the oldest value from these values, so sensor value has a few seconds delay.
This delay time almost equals to IP Webcam setting value of "Data logging > data retention (default 5 seconds)"

This patch pick up the latest value instead of the oldest one so that minimize latency of sensor data.

```
{
  "motion": {
    "unit": "",
    "data": [
      [
        1598592987171,
        [
          55
        ]
      ],
      [
        1598592987266,
        [
          41
        ]
      ],
(...)
      [
        1598592992171,
        [
          41
        ]
      ]
    ]
  },
(...)
}
```
