### PR TITLE
Split dev and production requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-aiohttp~=3.6.2
+aiohttp==3.7.4

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 """Set up pydroid_ipcam package."""
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 long_description = open("README.md").read()
+
+REQUIRES = ["aiohttp>=3.6.2"]
 
 setup(
     name="pydroid-ipcam",
@@ -17,7 +19,7 @@ setup(
     packages=["pydroid_ipcam"],
     zip_safe=True,
     platforms="any",
-    install_requires=list(val.strip() for val in open("requirements.txt")),
+    install_requires=REQUIRES,
     classifiers=[
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = lint, black
 [testenv]
 basepython = python3
 deps =
+    -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_tests.txt
 
 [testenv:lint]


### PR DESCRIPTION
- Pin aiohttp to 3.7.4 for dev (tox+CI) requirements.
- Make sure that tox installs all dev requirements.
- Require at least aiohttp 3.6.2 for production. This was the existing minimum version.