### PR TITLE
Add and raise library exceptions

### DIFF
--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -57,10 +57,10 @@ class PyDroidIPCam:
         """Return snapshot image URL."""
         return f"{self.base_url}/shot.jpg"
 
-    async def _request(self, path: str) -> Union[bool, Dict[str, Any], None]:
+    async def _request(self, path: str) -> Union[bool, Dict[str, Any]]:
         """Make the actual request and return the parsed response."""
         url: str = f"{self.base_url}{path}"
-        data: Union[bool, Dict[str, Any], None] = None
+        data: Union[bool, Dict[str, Any]]
 
         try:
             async with self.websession.get(

--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -73,7 +73,7 @@ class PyDroidIPCam:
 
         except aiohttp.ClientResponseError as error:
             if error.status == 401:
-                raise Unauthorized("Username or password are incorrect") from error
+                raise Unauthorized("Incorrect username or password") from error
             raise PyDroidIPCamException(
                 f"code: {error.code}, error: {error.message}"
             ) from error

--- a/pydroid_ipcam/exceptions.py
+++ b/pydroid_ipcam/exceptions.py
@@ -1,0 +1,13 @@
+"""PyDroidIPCam excpetions."""
+
+
+class PyDroidIPCamException(Exception):
+    """Base exception for PyDroidIPCam."""
+
+
+class Unauthorized(PyDroidIPCamException):
+    """Username or password is incorrect."""
+
+
+class CannotConnect(PyDroidIPCamException):
+    """Exception raised when failed to connect the client."""


### PR DESCRIPTION
## Breaking Changes

The `available` attribute has been removed. Library exceptions are raised in case of response error or timeout.

## Proposed Changes

- Raise exceptions for incorrect credentials or connection errors.
- Remove the `available` attribute and instead raise exceptions in case of connection issues.

Issues resolves in this PR: #116 