### PR TITLE
Return `ClientResponse` from `_request` and add methods for sensor value and unit

### DIFF
--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -106,12 +106,12 @@ class PyDroidIPCam:
     @property
     def enabled_sensors(self) -> List[str]:
         """Return the enabled sensors."""
-        return list(self.sensor_data.keys())
+        return list(self.sensor_data)
 
     @property
     def enabled_settings(self) -> List[str]:
         """Return the enabled settings."""
-        return list(self.status_data.get("curvals", {}).keys())
+        return list(self.status_data.get("curvals", {}))
 
     @property
     def available_settings(self) -> Dict[str, List[Any]]:
@@ -132,21 +132,6 @@ class PyDroidIPCam:
                 available[key].append(subval)
 
         return available
-
-    def export_sensor(self, sensor: str) -> Tuple[Optional[str], Any]:
-        """Return (value, unit) from a sensor node."""
-        value = None
-        unit = None
-        try:
-            container: Dict[str, Any] = self.sensor_data.get(sensor)  # type: ignore
-            unit = container.get("unit")
-            data_point = container.get("data", [[0, [0.0]]])
-            if data_point and data_point[-1]:
-                value = data_point[-1][-1][0]
-        except (ValueError, KeyError, AttributeError):
-            pass
-
-        return (value, unit)
 
     def get_sensor_value(self, sensor: str) -> Union[str, int, float, None]:
         """Return the value from a sensor node."""

--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -1,6 +1,6 @@
 """PyDroidIPCam API for the Android IP Webcam app."""
 import asyncio
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 import aiohttp
 from yarl import URL
@@ -154,19 +154,19 @@ class PyDroidIPCam:
         else:
             payload = val
         response = await self._request(f"/settings/{key}?set={payload}")
-        return cast(bool, "Ok" in (await response.text()))
+        return "Ok" in (await response.text())
 
     async def torch(self, activate: bool = True) -> bool:
         """Enable/disable the torch."""
         path = "/enabletorch" if activate else "/disabletorch"
         response = await self._request(path)
-        return cast(bool, "Ok" in (await response.text()))
+        return "Ok" in (await response.text())
 
     async def focus(self, activate: bool = True) -> bool:
         """Enable/disable camera focus."""
         path = "/focus" if activate else "/nofocus"
         response = await self._request(path)
-        return cast(bool, "Ok" in (await response.text()))
+        return "Ok" in (await response.text())
 
     async def record(self, record: bool = True, tag: Optional[str] = None) -> bool:
         """Enable/disable recording."""
@@ -174,7 +174,7 @@ class PyDroidIPCam:
         if record and tag is not None:
             path = f"/startvideo?force=1&tag={URL(tag).raw_path}"
         response = await self._request(path)
-        return cast(bool, "Ok" in (await response.text()))
+        return "Ok" in (await response.text())
 
     async def set_front_facing_camera(self, activate: bool = True) -> bool:
         """Enable/disable the front-facing camera."""
@@ -209,7 +209,7 @@ class PyDroidIPCam:
     async def set_zoom(self, zoom: int) -> bool:
         """Set the zoom level."""
         response = await self._request(f"/settings/ptz?zoom={zoom}")
-        return cast(bool, "Ok" in (await response.text()))
+        return "Ok" in (await response.text())
 
     async def set_scenemode(self, scenemode: str = "auto") -> bool:
         """Set the video scene mode."""

--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -148,6 +148,19 @@ class PyDroidIPCam:
 
         return (value, unit)
 
+    def get_sensor_value(self, sensor: str) -> Union[str, int, float, None]:
+        """Return the value from a sensor node."""
+        if sensor_info := self.sensor_data.get(sensor):
+            if "data" in sensor_info:
+                return cast(Union[str, int, float], sensor_info["data"][-1][-1][0])
+        return None
+
+    def get_sensor_unit(self, sensor: str) -> Optional[str]:
+        """Return the unit from a sensor node."""
+        if sensor_info := self.sensor_data.get(sensor):
+            return cast(Optional[str], sensor_info.get("unit"))
+        return None
+
     async def change_setting(self, key: str, val: Union[str, int, bool]) -> bool:
         """Change a setting."""
         payload: Union[str, int, None] = None

--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -154,19 +154,19 @@ class PyDroidIPCam:
         else:
             payload = val
         response = await self._request(f"/settings/{key}?set={payload}")
-        return (await response.text()).find("Ok") != -1
+        return cast(bool, "Ok" in (await response.text()))
 
     async def torch(self, activate: bool = True) -> bool:
         """Enable/disable the torch."""
         path = "/enabletorch" if activate else "/disabletorch"
         response = await self._request(path)
-        return (await response.text()).find("Ok") != -1
+        return cast(bool, "Ok" in (await response.text()))
 
     async def focus(self, activate: bool = True) -> bool:
         """Enable/disable camera focus."""
         path = "/focus" if activate else "/nofocus"
         response = await self._request(path)
-        return (await response.text()).find("Ok") != -1
+        return cast(bool, "Ok" in (await response.text()))
 
     async def record(self, record: bool = True, tag: Optional[str] = None) -> bool:
         """Enable/disable recording."""
@@ -174,7 +174,7 @@ class PyDroidIPCam:
         if record and tag is not None:
             path = f"/startvideo?force=1&tag={URL(tag).raw_path}"
         response = await self._request(path)
-        return (await response.text()).find("Ok") != -1
+        return cast(bool, "Ok" in (await response.text()))
 
     async def set_front_facing_camera(self, activate: bool = True) -> bool:
         """Enable/disable the front-facing camera."""
@@ -209,7 +209,7 @@ class PyDroidIPCam:
     async def set_zoom(self, zoom: int) -> bool:
         """Set the zoom level."""
         response = await self._request(f"/settings/ptz?zoom={zoom}")
-        return (await response.text()).find("Ok") != -1
+        return cast(bool, "Ok" in (await response.text()))
 
     async def set_scenemode(self, scenemode: str = "auto") -> bool:
         """Set the video scene mode."""


### PR DESCRIPTION
## Breaking Changes
`export_sensor` has been removed. Use `get_sensor_value` and `get_sensor_unit` instead.
## Proposed Changes

- Return `ClientResponse` from `_request` to be handled by each method as required.
- Initialize `self.status_data` and `self.sensor_data` as `dict` and remove checks for `None`.
- Add separate methods to retrieve sensor value and unit.