### PR TITLE
Better RTSP protocol handling

### DIFF
--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -68,9 +68,15 @@ class PyDroidIPCam:
         video_codec: Literal["jpeg", "h264"] = "h264",
         audio_codec: Literal["ulaw", "alaw", "pcm", "opus", "aac"] = "opus",
     ) -> str:
-        """Return the RTSP URL for a given pair of video & audio codecs, using the developer-recommended h264 & opus if no arguments are supplied."""
+        """Return the RTSP URL for a given pair of video & audio codecs.
+
+        Use the developer-recommended h264 & opus if no arguments are supplied.
+        """
         rtsp_protocol = "rtsps" if self._ssl else "rtsp"
-        return f"{rtsp_protocol}://{self._host}:{self._port}/{video_codec}_{audio_codec}.sdp"
+        return (
+            f"{rtsp_protocol}://{self._host}:{self._port}/"
+            f"{video_codec}_{audio_codec}.sdp"
+       )
 
     @property
     def h264_url(self) -> str:

--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -1,7 +1,7 @@
 """PyDroidIPCam API for the Android IP Webcam app."""
 
 import asyncio
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast, Literal
 
 import aiohttp
 from yarl import URL
@@ -63,10 +63,15 @@ class PyDroidIPCam:
         """Return url that LibOPUS audio can be streamed from."""
         return f"{self.base_url}/audio.opus"
 
+    def get_rtsp_url(self, video_codec: Literal["jpeg", "h264"] = "h264", audio_codec: Literal["ulaw", "alaw", "pcm", "opus", "aac"] = "opus") -> str:
+        """Return the RTSP URL for a given pair of video & audio codecs."""
+        rtsp_protocol = "rtsps" if self._ssl else "rtsp"
+        return f"{rtsp_protocol}://{self._host}:{self._port}/{video_codec}_{audio_codec}.sdp"
+
     @property
     def h264_url(self) -> str:
         """Return h264 url."""
-        return f"rtsp://{self._host}:{self._port}/h264_pcm.sdp"
+        return self.get_rtsp_url("h264", "pcm")
 
     @property
     def image_url(self) -> str:

--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -76,7 +76,7 @@ class PyDroidIPCam:
         return (
             f"{rtsp_protocol}://{self._host}:{self._port}/"
             f"{video_codec}_{audio_codec}.sdp"
-       )
+        )
 
     @property
     def h264_url(self) -> str:

--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -64,7 +64,7 @@ class PyDroidIPCam:
         return f"{self.base_url}/audio.opus"
 
     def get_rtsp_url(self, video_codec: Literal["jpeg", "h264"] = "h264", audio_codec: Literal["ulaw", "alaw", "pcm", "opus", "aac"] = "opus") -> str:
-        """Return the RTSP URL for a given pair of video & audio codecs."""
+        """Return the RTSP URL for a given pair of video & audio codecs, using the developer-recommended h264 & opus if no arguments are supplied."""
         rtsp_protocol = "rtsps" if self._ssl else "rtsp"
         return f"{rtsp_protocol}://{self._host}:{self._port}/{video_codec}_{audio_codec}.sdp"
 

--- a/pydroid_ipcam/__init__.py
+++ b/pydroid_ipcam/__init__.py
@@ -63,7 +63,11 @@ class PyDroidIPCam:
         """Return url that LibOPUS audio can be streamed from."""
         return f"{self.base_url}/audio.opus"
 
-    def get_rtsp_url(self, video_codec: Literal["jpeg", "h264"] = "h264", audio_codec: Literal["ulaw", "alaw", "pcm", "opus", "aac"] = "opus") -> str:
+    def get_rtsp_url(
+        self,
+        video_codec: Literal["jpeg", "h264"] = "h264",
+        audio_codec: Literal["ulaw", "alaw", "pcm", "opus", "aac"] = "opus",
+    ) -> str:
         """Return the RTSP URL for a given pair of video & audio codecs, using the developer-recommended h264 & opus if no arguments are supplied."""
         rtsp_protocol = "rtsps" if self._ssl else "rtsp"
         return f"{rtsp_protocol}://{self._host}:{self._port}/{video_codec}_{audio_codec}.sdp"


### PR DESCRIPTION
This PR adds better RTSP protocol handling, including support for the more compatible "h264" & "opus." It also adds support for RTSP over SSL via RTSPS, and updates the h264_url property to use the new method.

I will use this function to add native streaming to core using the stream integration, would it be ok to ask for a **version bump** (2.0.0 -> 2.1.0) so I can pin it to the changes added, if you choose to merge this PR? Thank you.
