### PR TITLE
Require Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7.0.0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6.3.0
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 description = "Library for handling the Android IP Webcam app"
 readme = "README.md"
 authors = [{ name = "Pascal Vizeli", email = "pvizeli@syshack.ch" }]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",


### PR DESCRIPTION
- Python 3.9 was end of life in October 2025.